### PR TITLE
Display questions belonging to compared scenarios.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,6 +22,7 @@ class PagesController < ApplicationController
     @scenarios = scenarios.to_a.sort_by{|s| s.send @order.to_sym}
     @scenarios.reverse! if @direction == 'desc'
     @scenarios.each_with_index { |s, i| s.title = "<anonymous>" ; s.name = "person ##{s.id}" } if params[:anonymous]
+    @questions = @scenarios.first.answers.map(&:question)
   end
 
   private

--- a/app/views/pages/analysis.html.haml
+++ b/app/views/pages/analysis.html.haml
@@ -32,7 +32,7 @@
         %td.dont_print= link_to 'Answers', answers_scenario_path(scenario), :target => '_blank'
 
 .scenarios_stats
-  - question_set.questions.enabled.ordered.each_with_index do |question, idx|
+  - @questions.each_with_index do |question, idx|
     %table.answer_stats
       %tr
         %th.title{:colspan => 2} #{idx + 1}. #{question.text}


### PR DESCRIPTION
Before, when you ran `analysis`, the results page would loop through
the questions of the `question_set` of the current `Partition`.

However, when you want to compare old scenarios that have (currently)
disabled questions, this does not work.

Please take into account that all the scenarios should have been made
with the **same** questions!
